### PR TITLE
Normalize output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-build
 bin
 nbproject/
 *.a

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJECTS=$(patsubst %.cpp,%.o,$(SOURCES))
 TEST_SRC=$(wildcard tests/*_tests.cpp)
 TESTS=$(patsubst %.cpp,%,$(TEST_SRC))
 
-TARGET=build/isextract
+TARGET=bin/isextract
 SO_TARGET=$(patsubst %.a,%.so,$(TARGET))
 
 # The Target Build
@@ -27,7 +27,6 @@ $(TARGET): build $(OBJECTS)
 	$(CC) $(OBJECTS) -o $(TARGET)
 
 build:
-	@mkdir -p build
 	@mkdir -p bin
 
 # The Cleaner
@@ -39,8 +38,8 @@ clean:
 
 # The Install
 install: all
-	install -d $(DESTDIR)/$(PREFIX)/lib/
-	install $(TARGET) $(DESTDIR)/$(PREFIX)/lib/
+	install -d $(DESTDIR)/$(PREFIX)/bin/
+	install $(TARGET) $(DESTDIR)/$(PREFIX)/bin/
 
 # The Checker
 BADFUNCS='[^_.>a-zA-Z0-9](str(n?cpy|n?cat|xfrm|n?dup|str|pbrk|tok|_)|stpn?cpy|a?sn?printf|byte_)'


### PR DESCRIPTION
Previously, one target would send isextract to build, one would send it
to lib, and another would create an unused bin folder. This change makes
isextract more consistent with itself and more consistent with Unix
tradition.