### PR TITLE
Removed deprecated egrep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ install: all
 BADFUNCS='[^_.>a-zA-Z0-9](str(n?cpy|n?cat|xfrm|n?dup|str|pbrk|tok|_)|stpn?cpy|a?sn?printf|byte_)'
 check:
 	@echo Files with potentially dangerous functions.
-	@egrep $(BADFUNCS) $(SOURCES) || true
+	@grep -E $(BADFUNCS) $(SOURCES) || true


### PR DESCRIPTION
"Direct invocation as either egrep or fgrep is deprecated..."
-- The GNU Grep manual
<https://www.gnu.org/software/grep/manual/grep.html#grep-Programs>